### PR TITLE
GET Helm Chart Fix

### DIFF
--- a/charts/enterprise-traces/templates/tokengen/job-tokengen.yaml
+++ b/charts/enterprise-traces/templates/tokengen/job-tokengen.yaml
@@ -80,7 +80,7 @@ spec:
           command:
             - /bin/bash
             - -euc
-            - kubectl create secret generic gel-admin-token --from-file=token=/shared/admin-token --from-literal=grafana-token="$(base64 <(echo :$(cat /shared/admin-token)))"
+            - kubectl create secret generic get-admin-token --from-file=token=/shared/admin-token --from-literal=grafana-token="$(base64 <(echo :$(cat /shared/admin-token)))"
           volumeMounts:
             {{- if .Values.tokengen.extraVolumeMounts }}
               {{ toYaml .Values.tokengen.extraVolumeMounts | nindent 12 }}

--- a/charts/enterprise-traces/values.yaml
+++ b/charts/enterprise-traces/values.yaml
@@ -20,37 +20,29 @@ externalLicenseVersion: "0"
 license:
   contents: "NOTAVALIDLICENSE"
 
-# TODO: Needs to fold into tempo-distributed
 storage: &storage
   trace:
     backend: s3
     s3:
-      #endpoint: http://lab-get-minio.lab-get.svc:9000
+      # CHANGE lab-get TO YOUR NAMESPACE IN THE LINE BELOW
       endpoint: lab-get-minio.lab-get.svc:9000
-      #bucket_name: enterprise-traces-admin
       bucket: enterprise-traces-admin
-      #access_key_id: enterprise-traces
       access_key: enterprise-traces
-      #secret_access_key: supersecret
       secret_key: supersecret
       insecure: true
 
-# TODO: Needs to fold into tempo-distributed
 compactor:
   config:
     compaction:
       block_retention: 48h
 
-# TODO: Needs to fold into tempo-distributed
 server: &server
   http_listen_port: 3100
   grpc_listen_port: 9095
 
-# TODO: Needs to fold into tempo-distributed
 search:
   enabled: false
 
-# TODO: Needs to fold into tempo-distributed
 traces:
   jaeger:
     grpc: false
@@ -64,13 +56,11 @@ traces:
   opencensus: false
   kafka: {}
 
-# TODO: Needs to fold into tempo-distributed
 querier:
   config:
     frontend_worker:
       grpc_client_config: {}
 
-# TODO: Needs to fold into tempo-distributed
 queryFrontend:
   config: |
     backend: 127.0.0.1:3100

--- a/charts/enterprise-traces/values.yaml
+++ b/charts/enterprise-traces/values.yaml
@@ -26,7 +26,7 @@ storage: &storage
     s3:
       # CHANGE lab-get TO YOUR NAMESPACE IN THE LINE BELOW
       endpoint: lab-get-minio.lab-get.svc:9000
-      bucket: enterprise-traces-admin
+      bucket: enterprise-traces-data
       access_key: enterprise-traces
       secret_key: supersecret
       insecure: true

--- a/charts/enterprise-traces/values.yaml
+++ b/charts/enterprise-traces/values.yaml
@@ -3,7 +3,7 @@
 image: &image
   registry: docker.io
   repository: grafana/enterprise-traces
-  tag: v1.2.1
+  tag: v1.3.0
   pullPolicy: IfNotPresent
 
 serviceAccount:
@@ -21,15 +21,19 @@ license:
   contents: "NOTAVALIDLICENSE"
 
 # TODO: Needs to fold into tempo-distributed
-storage:
+storage: &storage
   trace:
     backend: s3
     s3:
-      endpoint: |
-        {{ include "enterprise-traces.minio" . }}
-      bucket: enterprise-traces-blocks
+      #endpoint: http://lab-get-minio.lab-get.svc:9000
+      endpoint: lab-get-minio.lab-get.svc:9000
+      #bucket_name: enterprise-traces-admin
+      bucket: enterprise-traces-admin
+      #access_key_id: enterprise-traces
       access_key: enterprise-traces
+      #secret_access_key: supersecret
       secret_key: supersecret
+      insecure: true
 
 # TODO: Needs to fold into tempo-distributed
 compactor:
@@ -38,7 +42,7 @@ compactor:
       block_retention: 48h
 
 # TODO: Needs to fold into tempo-distributed
-server:
+server: &server
   http_listen_port: 3100
   grpc_listen_port: 9095
 
@@ -70,36 +74,34 @@ querier:
 queryFrontend:
   config: |
     backend: 127.0.0.1:3100
-
 overrides: |
   overrides: {}
 
 # TODO: Replace all non enterprise .Values to:
 # `index .Values "tempo-distributed" key1 key2 ...`
-config: |
+config: &config |
   auth:
     type: enterprise
   auth_enabled: true
-
   license:
     path: /etc/enterprise-traces/license/license.jwt
-
   cluster_name: {{.Release.Name}}
-
   server:
-    {{toYaml .Values.server | nindent 4}}
-
+    http_listen_port: {{ .Values.server.http_listen_port }}
+    grpc_listen_port: {{ .Values.server.grpc_listen_port }}
   admin_client:
     storage:
       type: s3
       s3:
-        endpoint: |
-          {{ include "enterprise-traces.minio" . }}
-        bucket: enterprise-traces-admin
-        access_key: enterprise-traces
-        secret_key: supersecret
-
-  multitenancy_enabled: false
+        endpoint: {{ .Release.Namespace }}-minio.{{ .Release.Namespace }}.svc:9000
+        bucket_name: enterprise-traces-admin
+        access_key_id: enterprise-traces
+        secret_access_key: supersecret
+        insecure: true
+  multitenancy_enabled: true
+  admin_api:
+    leader_election:
+      enabled: false
   search_enabled: {{.Values.search.enabled}}
   compactor:
     compaction:
@@ -107,6 +109,22 @@ config: |
     ring:
       kvstore:
         store: memberlist
+  gateway:
+    proxy:
+      default:
+        url: http://{{ .Release.Name }}-enterprise-traces-admin-api.{{ .Release.Namespace }}.svc:3100
+      admin_api:
+        url: http://{{ .Release.Name }}-enterprise-traces-admin-api.{{ .Release.Namespace }}.svc:3100
+      compactor:
+        url: http://{{ .Release.Name }}-enterprise-traces-compactor.{{ .Release.Namespace }}.svc:3100
+      distributor:
+        url: h2c://{{ .Release.Name }}-enterprise-traces-distributor.{{ .Release.Namespace }}.svc:4317
+      ingester:
+        url: http://{{ .Release.Name }}-enterprise-traces-ingester.{{ .Release.Namespace }}.svc:3100
+      querier:
+        url: http://{{ .Release.Name }}-enterprise-traces-querier.{{ .Release.Namespace }}.svc:3100
+      query_frontend:
+        url: http://{{ .Release.Name }}-enterprise-traces-query-frontend.{{ .Release.Namespace }}.svc:3100      
   distributor:
     ring:
       kvstore:
@@ -268,8 +286,19 @@ tempo-distributed:
 
   gateway:
     enabled: false
+  server: *server
+  storage: *storage
+  config: *config
+  ingester:
+    extraVolumes:
+      - name: license
+        secret:
+          secretName: enterprise-traces-license
+    extraVolumeMounts:
+      - name: license
+        mountPath: /etc/enterprise-traces/license
 
-  ingester: &extras
+  distributor: &extras
     extraVolumes:
       - name: license
         secret:
@@ -282,11 +311,19 @@ tempo-distributed:
       - name: storage
         mountPath: /var/tempo
 
-  distributor: *extras
+  traces:
+    otlp:
+      http:
+        enabled: true
+      grpc:
+        enabled: true
 
   querier: *extras
 
-  queryFrontend: *extras
+  queryFrontend:
+    <<: *extras
+    query:
+      enabled: false
 
   compactor: *extras
 


### PR DESCRIPTION
Adding fixes to GET helm chart. Should run successfully without additional values files, I ran 

> helm install lab-get -n lab-get ./helm-charts-get/charts/enterprise-traces

Would like to change the instruction on line 27 of the /helm-charts-get/charts/enterprise-traces/values.yaml file to not require manual substitution.